### PR TITLE
add possibility to simulate effect of item #101

### DIFF
--- a/src/app/modules/deck-modifiers/deck-modifiers.component.html
+++ b/src/app/modules/deck-modifiers/deck-modifiers.component.html
@@ -17,6 +17,7 @@
     </mat-form-field>
     <mat-form-field fxFlex="30%">
         <mat-select placeholder="-1 Cards" [(value)]="deck.deckModifiers['-1']">
+          <mat-option [value]="-2">-2</mat-option>
           <mat-option *ngFor="let character of ' '.repeat(11).split(''), let i = index" [value]="i">
             {{ i }}
           </mat-option>


### PR DESCRIPTION
[item 101](https://www.reddit.com/r/Gloomhaven/wiki/items/item_101) removes two `-1` cards from the modifier deck.

Downside of the implementation in this PR is that it makes it possible to get into situations where a deck would end up with a negative amount of `-1` cards (e.g. minus two `-1` cards from second skin + twice "remove two `-1` cards" from regular perks), which is not realistic. :thinking: Also, maybe a dedicated list of checkboxes for (armour) items would make sense?